### PR TITLE
Fix default service flags for RHEL8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,14 @@ class spamassassin::params {
       'Redhat': {
           $spamd_options_file   = '/etc/sysconfig/spamassassin'
           $spamd_options_var    = 'SPAMDOPTIONS'
-          $spamd_defaults       = '-d -c -H'
+          case $::operatingsystemmajrelease {
+            '6', '7': {
+              $spamd_defaults   = '-d -c -H'
+            }
+            default: {
+              $spamd_defaults   = '-c -H'
+            }
+          }
           $sa_update_file       = '/etc/sysconfig/sa-update'
       }
       default: {


### PR DESCRIPTION
While trying to standup a new CentOS 8 system using this module I
discovered that the default service options were causing spamd to
constantly restart. After some in depth testing I found that the '-d'
option which may be needed for RHEL6 was causing the problem. As I no
longer have any RHEL7 based systems to test I don't know if it's needed
for version 7 or not, but I'm going to go out and assume that it is
since no updates were provided previously!

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>