### PR TITLE
Add CentOS 7 and 8 as supported distros

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6"
+        "6","7","8"
       ]
     },
     {


### PR DESCRIPTION
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>