### PR TITLE
stdlib version bump and OS compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -24,6 +24,12 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "8","9","10"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "20.04"
       ]
     }
   ],


### PR DESCRIPTION
Changes needed to successfully deploy on Ubuntu 20.04 with newest available `puppetlabs/stdlib`