### PR TITLE
Add custom_config option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -225,6 +225,16 @@ spamassassin::custom_rules:
     describe: 'spam reported claiming "You have received an invoice"'
 ```
 
+#### `custom_config`
+Add custom lines to the config file. Useful for configuring modules that aren't otherwise
+handled by this Puppet module. This is an array of strings, e.g:
+
+```puppet
+spamassassin::custom_config:
+  - hashcash_accept *@example.com
+  - hashcash_accept *@example.net
+```
+
 #### `whitelist_from`
 Used to whitelist sender addresses which send mail that is often
 tagged (incorrectly) as spam. This would be written to the global

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -137,6 +137,7 @@ class spamassassin::config {
     dkim_enabled                       => $spamassassin::dkim_enabled,
     dkim_timeout                       => $spamassassin::dkim_timeout,
     custom_rules                       => $spamassassin::custom_rules,
+    custom_config                      => $spamassassin::custom_config,
   }
   file { "${spamassassin::configdir}/local.cf":
     ensure  => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,6 +88,14 @@
 #     score: 6
 #     describe: 'spam reported claiming "You have received an invoice"'
 #
+# [*custom_config*]
+# Add custom lines to the config file. Useful for configuring modules that aren't otherwise
+# handled by this Puppet module. This is an array of strings, e.g:
+#
+# spamassassin::custom_config:
+#   - hashcash_accept *@example.com
+#   - hashcash_accept *@example.net
+#
 # [*whitelist_from*]
 # Used to whitelist sender addresses which send mail that is often
 # tagged (incorrectly) as spam. This would be written to the global
@@ -571,6 +579,7 @@ class spamassassin (
   Boolean $rules2xsbody_enabled = false,
   # custom rules
   Hash $custom_rules = {},
+  Array[String] $custom_config                                                = [],
 ) inherits spamassassin::params {
 
   if $spamd_sql_config and (

--- a/spec/classes/spamassassin_spec.rb
+++ b/spec/classes/spamassassin_spec.rb
@@ -320,6 +320,14 @@ describe 'spamassassin' do
         }
       end
 
+      describe "with custom config" do
+        let(:params) {{ custom_config: [ 'hashcash_accept *@example.com' ] }}
+
+        it { should contain_file('/etc/mail/spamassassin/local.cf').with({
+          'content' => %r{^hashcash_accept *@example.com$}})
+        }
+      end
+
     end
   end
 end

--- a/templates/local_cf.epp
+++ b/templates/local_cf.epp
@@ -248,3 +248,8 @@ dkim_timeout       <%= $dkim_timeout %>
     <%- } -%>
   <%- } -%>
 <%- } -%>
+
+<% if $custom_config { -%>
+# custom_config:
+<%= $custom_config.join("\n") %>
+<% } -%>


### PR DESCRIPTION
This MR adds a new `spamassassin::custom_config` parameter, enabling users to add full lines to the config file. Useful for configuration that isn't otherwise handled by this Puppet module (such as custom site-specific SpamAssassin plugins).