### PR TITLE
Add support for a custom service name + Debian 12 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -163,9 +163,17 @@ like the razor-admin or pyzor discover commands
 to be run as a different user specify the username
 in this directive. Example: amavis. Default: undef
 
+#### `package_name`
+String. The package name to use.
+Default: Distribution specific
+
 #### `service_enable`
 Boolean. Will enable service at boot
 and ensure a running service.
+
+#### `service_name`
+String. The service name to use for the spamassassin service.
+Default: Distribution specific
 
 #### `spamd_max_children`
 This option specifies the maximum number of children to spawn.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,9 +15,17 @@
 # to be run as a different user specify the username
 # in this directive. Example: amavis. Default: undef
 #
+# [*package_name*]
+# String. The package name to use.
+# Default: Distribution specific
+#
 # [*service_enabled*]
 # Boolean. Will enable service at boot
 # and ensure a running service.
+#
+# [*service_name*]
+# String. The service name to use for the spamassassin service.
+# Default: Distribution specific
 #
 # [*notify_service_name*]
 # String. If specified then this service will be notified instead of "spamd"
@@ -474,8 +482,10 @@
 class spamassassin (
   Boolean          $sa_update         = false,
   Optional[String] $run_execs_as_user = undef,
+  String           $package_name      = $spamassassin::params::package_name,
   # Spamd settings
   Boolean              $service_enabled      = false,
+  String               $service_name         = $spamassassin::params::service_name,
   Optional[String]     $notify_service_name  = undef,
   Integer[1]           $spamd_max_children   = 5,
   Optional[Integer[1]] $spamd_min_children   = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,6 +28,7 @@ class spamassassin::install {
 
   package { 'spamassassin':
     ensure => installed,
+    name   => $spamassassin::package_name,
   }
 
   if $spamassassin::pyzor_enabled {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,12 +11,21 @@ class spamassassin::params {
 
   case $facts['os']['family'] {
     'Debian': {
+      if versioncmp($facts['os']['release']['major'], '12') >= 0 {
+        $service_name = 'spamd'
+        $package_name = 'spamd'
+      } else {
+        $service_name = 'spamassassin'
+        $package_name = 'spamassassin'
+      }
       $spamd_options_file   = '/etc/default/spamassassin'
       $spamd_options_var    = 'OPTIONS'
       $spamd_defaults       = '-c -H'
       $sa_update_file       = $spamd_options_file
     }
     'Redhat': {
+      $service_name = 'spamassassin'
+      $package_name = 'spamassassin'
       $spamd_options_file   = '/etc/sysconfig/spamassassin'
       $spamd_options_var    = 'SPAMDOPTIONS'
       case $facts['os']['release']['major'] {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,6 +8,7 @@
 class spamassassin::service {
   service { 'spamassassin':
     ensure  => $spamassassin::service_enabled,
+    name    => $spamassassin::service_name,
     enable  => $spamassassin::service_enabled,
     pattern => 'spamd',
     require => Package['spamassassin'],

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10", "11"
+        "10", "11", "12"
       ]
     },
     {


### PR DESCRIPTION
Since Debian 12, the service name changed from spamassassin to spamd