### PR TITLE
fix: package name on ubuntu prior to noble

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,12 +11,25 @@ class spamassassin::params {
 
   case $facts['os']['family'] {
     'Debian': {
-      if versioncmp($facts['os']['release']['major'], '12') >= 0 {
-        $service_name = 'spamd'
-        $package_name = 'spamd'
-      } else {
-        $service_name = 'spamassassin'
-        $package_name = 'spamassassin'
+      case $facts['os']['name'] {
+        'Ubuntu': {
+          if versioncmp($facts['os']['release']['major'], '24') >= 0 {
+            $service_name = 'spamd'
+            $package_name = 'spamd'
+          } else {
+            $service_name = 'spamassassin'
+            $package_name = 'spamassassin'
+          }
+        }
+        default: {
+          if versioncmp($facts['os']['release']['major'], '12') >= 0 {
+            $service_name = 'spamd'
+            $package_name = 'spamd'
+          } else {
+            $service_name = 'spamassassin'
+            $package_name = 'spamassassin'
+          }
+        }
       }
       $spamd_options_file   = '/etc/default/spamassassin'
       $spamd_options_var    = 'OPTIONS'

--- a/spec/classes/spamassassin_spec.rb
+++ b/spec/classes/spamassassin_spec.rb
@@ -19,6 +19,33 @@ describe 'spamassassin' do
     end
   end
 
+  context 'on Ubuntu' do
+    let :facts do
+      super().merge(
+        {
+          os: {
+            family: 'Debian',
+            name: 'Ubuntu',
+            release: {
+              major: '22.04',
+            },
+          },
+        }
+      )
+    end
+      it {
+        is_expected.to contain_package('spamassassin').with(
+          ensure: 'installed',
+          name: 'spamassassin'
+        )
+      }
+    it {
+      is_expected.to contain_service('spamassassin').with(
+        name: 'spamassassin',
+      )
+    }
+  end
+
   %w[Debian RedHat].each do |system|
     context "when on system #{system}" do
       let :facts do


### PR DESCRIPTION
The package `spamd` is available since noble.

The prior code used `spamd` as package name for all ubuntu versions.