### PR TITLE
fix the sa-update toggle on Debian 13

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -51,6 +51,7 @@ The following parameters are available in the `spamassassin` class:
 * [`spamd_options_var`](#-spamassassin--spamd_options_var)
 * [`spamd_defaults`](#-spamassassin--spamd_defaults)
 * [`sa_update_file`](#-spamassassin--sa_update_file)
+* [`manage_sa_update_file`](#-spamassassin--manage_sa_update_file)
 * [`required_score`](#-spamassassin--required_score)
 * [`score_tests`](#-spamassassin--score_tests)
 * [`whitelist_from`](#-spamassassin--whitelist_from)
@@ -341,6 +342,15 @@ Data type: `Stdlib::Absolutepath`
 Absolute path to file that contains shell variables for sa-update.
 
 Default value: `$spamd_options_file`
+
+##### <a name="-spamassassin--manage_sa_update_file"></a>`manage_sa_update_file`
+
+Data type: `Boolean`
+
+Own `File[$sa_update_file]`. Allows to create the file on OSes which do not
+ship it.
+
+Default value: `false`
 
 ##### <a name="-spamassassin--required_score"></a>`required_score`
 

--- a/data/Debian-13.yaml
+++ b/data/Debian-13.yaml
@@ -1,0 +1,10 @@
+---
+
+# Both spamd.service and /etc/init.d/spamd only source /etc/default/spamd
+spamassassin::spamd_options_file: '/etc/default/spamd'
+
+# On the other hand, /usr/sbin/spamassassin-maint (for
+# spamassassin-maintenance.timer) and /etc/cron.daily/spamassassin rely on
+# /etc/default/spamassassin
+spamassassin::sa_update_file: '/etc/default/spamassassin'
+spamassassin::manage_sa_update_file: true

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -208,6 +208,15 @@ class spamassassin::config {
         match   => '^CRON=[0-1]$',
         require => Package['spamassassin'],
       }
+      if $spamassassin::manage_sa_update_file {
+        file { $spamassassin::sa_update_file:
+          ensure => file,
+          owner  => root,
+          group  => root,
+          mode   => '0644',
+        }
+        Package['spamassassin'] -> File[$spamassassin::sa_update_file] -> File_line['sa_update']
+      }
     }
     'Redhat': {
       $saupdate = bool2str($spamassassin::sa_update, 'yes', 'no')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,9 @@
 #   parameters you may need to revise those deamon flags.
 # @param sa_update_file
 #   Absolute path to file that contains shell variables for sa-update.
+# @param manage_sa_update_file
+#   Own `File[$sa_update_file]`. Allows to create the file on OSes which do not
+#   ship it.
 #
 # @param required_score
 #   Set the score required before a mail is considered spam. Can be an integer
@@ -420,6 +423,7 @@ class spamassassin (
   String               $spamd_options_var  = 'OPTIONS',
   String               $spamd_defaults     = '-c -H',
   Stdlib::Absolutepath $sa_update_file     = $spamd_options_file,
+  Boolean              $manage_sa_update_file = false,
   # Scoring options, see Mail::SpamAssassin::Conf(3)
   Numeric              $required_score     = 5,
   Hash                 $score_tests        = {},

--- a/spec/classes/spamassassin_spec.rb
+++ b/spec/classes/spamassassin_spec.rb
@@ -7,6 +7,8 @@ describe 'spamassassin' do
     context "on #{os}" do
       let(:facts) { facts.merge({ is_virtual: 'false' }) }
 
+      debian13 = facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'] == '13'
+
       if (facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['major'] == '22') \
           || (facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'] == '11') \
           || facts[:os]['family'] == 'RedHat'
@@ -82,6 +84,24 @@ describe 'spamassassin' do
               },
             )
           }
+        elsif debian13
+          it 'writes the spamd service toggle to the Debian 13 spamd defaults file' do
+            is_expected.to contain_file_line('spamd_service').with(
+              {
+                'path' => '/etc/default/spamd',
+                'line' => %r{ENABLED=1},
+              },
+            )
+          end
+
+          it 'writes spamd options to the Debian 13 spamd defaults file' do
+            is_expected.to contain_file_line('spamd_options').with(
+              {
+                'path' => '/etc/default/spamd',
+                'line' => %r{OPTIONS="-c -H -m 5 -i localhost -A 127.0.0.1/32 -A \[::1\]/8"},
+              },
+            )
+          end
         else
           it {
             is_expected.to contain_file_line('spamd_service').with(
@@ -155,6 +175,15 @@ describe 'spamassassin' do
               },
             )
           }
+        elsif debian13
+          it 'writes the Debian 13 sa-update cron setting to the spamassassin defaults file' do
+            is_expected.to contain_file_line('sa_update').with(
+              {
+                'path' => '/etc/default/spamassassin',
+                'line' => %r{CRON=1},
+              },
+            ).that_requires(['File[/etc/default/spamassassin]'])
+          end
         else
           it {
             is_expected.to contain_file_line('sa_update').with(
@@ -164,6 +193,23 @@ describe 'spamassassin' do
               },
             )
           }
+        end
+      end
+
+      if debian13
+        describe 'with auto update enabled and sa-update defaults file management disabled' do
+          let(:params) { { manage_sa_update_file: false, sa_update: true } }
+
+          it {
+            is_expected.to contain_file_line('sa_update').with(
+              {
+                'path' => '/etc/default/spamassassin',
+                'line' => %r{CRON=1},
+              },
+            ).that_requires(['Package[spamassassin]'])
+          }
+
+          it { is_expected.not_to contain_file('/etc/default/spamassassin') }
         end
       end
 


### PR DESCRIPTION
Debian 13 uses different /etc/default files for spamd and for the sa-update cronjob.

- Point at the proper file for each: `CRON=1` belongs to /etc/default/spamassassin. It was ignored in /etc/default/spamd.
- Conditionally ensure /etc/default/spamassassin exists: Debian 13 does not ship the file, which breaks the file_line resource.

Note: on Debian 13, this module now manages `/etc/default/spamassassin` by default. This may be a breaking change for users who previously managed that file themselves as a workaround.